### PR TITLE
Improve excel error handling

### DIFF
--- a/goodtables/datatable/datatable.py
+++ b/goodtables/datatable/datatable.py
@@ -147,14 +147,19 @@ class DataTable(object):
         
         instream = None
         
-        try:
-            if compat.urlparse(data_source).scheme in self.REMOTE_SCHEMES:
-                instream = self._stream_from_url(data_source).read()
-        except Exception:
+        if compat.urlparse(data_source).scheme in self.REMOTE_SCHEMES:
+            instream = self._stream_from_url(data_source).read()
+        else:
             try:
+                data_source.seek(0)
                 instream = data_source.read()
-            except Exception:
-                pass
+            except AttributeError:
+                if os.path.exists(data_source):
+                    pass
+                else:
+                    msg = 'data source has to be a stream or a path to be processed as excel'
+                    raise exceptions.DataSourceMalformatedError(msg, file_format='excel')
+
         try:
             if instream:
                 workbook = xlrd.open_workbook(file_contents=instream)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -221,10 +221,10 @@ class TestPipeline(base.BaseTestCase):
 
         self.assertEqual(out, 33)
 
-    def test_pipeline_error_report_when_data_http_error(self):
+    def test_pipeline_error_report_when_data_http_error(self, format='csv'):
 
         data_source = 'https://github.com/frictionlessdata/goodtables/blob/master/.travis.yaml'
-        validator = Pipeline(data_source, fail_fast=True)
+        validator = Pipeline(data_source, format=format, fail_fast=True)
         result, report = validator.run()
         generated_report = report.generate()
         report_results = generated_report['results']
@@ -233,6 +233,9 @@ class TestPipeline(base.BaseTestCase):
         self.assertEqual(len(report_results), 1)
         self.assertEqual(report_results[0]['result_id'], 'http_404_error')
         
+    def test_excel_pipeline_error_report_when_data_http_error(self):
+        self.test_pipeline_error_report_when_data_http_error(format='excel')
+
     def test_pipeline_group_error_report_when_http_error(self):
 
         data_source = 'https://github.com/frictionlessdata/goodtables/blob/master/.travis.yaml'
@@ -320,3 +323,4 @@ class TestPipeline(base.BaseTestCase):
         pipeline = Pipeline(self.data_string)
         pipeline.set_report_meta()
         self.assertEqual(pipeline.report.generate()['meta']['encoding'], 'utf-8')
+    


### PR DESCRIPTION
Stop excel error handling from interfering with HTTP errors and make it handle strings that are not paths gracefully. 