### PR TITLE
Quote composed urls separately

### DIFF
--- a/goodtables/utilities/helpers.py
+++ b/goodtables/utilities/helpers.py
@@ -208,7 +208,11 @@ def make_valid_url(url):
     Args:
         * `url`: a url string
     """
-    
+    if '/+/http' in url:
+        glue = '/+/'
+        quoted = [make_valid_url(unquoted) for unquoted in url.split(glue)]
+        return (glue).join(quoted)
+
     scheme, netloc, path, query, fragment = compat.urlsplit(url)
     quoted_path = compat.quote(path.encode('utf-8'))
     quoted_query = compat.quote_plus(query.encode('utf-8'))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -19,3 +19,15 @@ class TestUtilities(base.BaseTestCase):
 
     def test_get_report_result_types(self):
         self.assertTrue(utilities.helpers.get_report_result_types())
+
+    def test_make_valid_composed_url(self):
+        url = ('http://webarchive.nationalarchives.gov.uk/+/'
+               'http://www.nio.gov.uk/transaction_spend_data_august_10_northern_ireland_office.xls')
+        assertion = '+' in utilities.helpers.make_valid_url(url)
+        self.assertTrue(assertion)
+
+    def test_make_valid_url(self):
+        url = ('http://goodtables.okfnlabs.org/reports?'
+              'data_url=http://data.defra.gov.uk/ops/government_procurement_card/over_£500_GPC_apr_2013.csv')
+        assertion = '£' not in utilities.helpers.make_valid_url(url)
+        self.assertTrue(assertion)


### PR DESCRIPTION
[urllib](https://docs.python.org/2/library/urllib.html) doesn't support composed URLs like `http://webarchive.nationalarchives.gov.uk/+/http://www.nio.gov.uk/transaction_spend_data_august_10_northern_ireland_office.xls`. Because it doesn't recognize there are 2 URLs in that string, it's quoting the `/+/http://` part, which results in those URLs returning 500.  This is a workaround to that issue. 