### PR TITLE
Improve CSV dialect detector accuracy

### DIFF
--- a/goodtables/compat.py
+++ b/goodtables/compat.py
@@ -33,7 +33,7 @@ if is_py2:
     def csv_reader(data, dialect=csv.excel, **kwargs):
         """Read text stream (unicode on Py2.7) as CSV."""
 
-        first_lines = list(islice(data, 10))
+        first_lines = list(islice(data, 5))
         try:
             dialect = csv.Sniffer().sniff(''.join(first_lines))
             dialect.delimiter = dialect.delimiter.encode('utf-8')
@@ -73,7 +73,7 @@ elif is_py3:
             for line in data:
                 yield line
         iter = line_iterator(data)
-        first_lines = list(islice(iter, 10))
+        first_lines = list(islice(iter, 5))
         try:
             dialect = csv.Sniffer().sniff(''.join(first_lines))
         except csv.Error:

--- a/goodtables/compat.py
+++ b/goodtables/compat.py
@@ -30,10 +30,10 @@ if is_py2:
     basestring = basestring
     numeric_types = (int, long, float)
 
-    def csv_reader(data, dialect=csv.excel, **kwargs):
+    def csv_reader(data, dialect=csv.excel, header_index=0, **kwargs):
         """Read text stream (unicode on Py2.7) as CSV."""
 
-        first_lines = list(islice(data, 5))
+        first_lines = list(islice(data, header_index, header_index + 2))
         try:
             dialect = csv.Sniffer().sniff(''.join(first_lines))
             dialect.delimiter = dialect.delimiter.encode('utf-8')
@@ -67,18 +67,20 @@ elif is_py3:
     basestring = (str, bytes)
     numeric_types = (int, float)
 
-    def csv_reader(data, **kwargs):
+    def csv_reader(data, header_index, **kwargs):
 
         def line_iterator(data):
             for line in data:
                 yield line
-        iter = line_iterator(data)
-        first_lines = list(islice(iter, 5))
+
+        first_lines = list(islice(data, header_index, header_index + 2))
+        data.seek(0)
         try:
             dialect = csv.Sniffer().sniff(''.join(first_lines))
         except csv.Error:
             dialect = csv.excel
-        iter = chain(first_lines, iter)
+
+        iter = line_iterator(data)
         csv.field_size_limit(20000000)
         try:
             return csv.reader(iter, dialect, **kwargs)

--- a/goodtables/datatable/datatable.py
+++ b/goodtables/datatable/datatable.py
@@ -59,7 +59,7 @@ class DataTable(object):
 
     def extract(self, headers=None):
         """Extract headers and values from the data stream."""
-        reader = compat.csv_reader(self.stream)
+        reader = compat.csv_reader(self.stream, self.header_index)
         headers = headers or self.get_headers(self.stream, reader)
         return headers, reader
 
@@ -69,7 +69,7 @@ class DataTable(object):
         sample = self._sample_stream(row_limit)
 
         self.replay()
-        return compat.csv_reader(sample)
+        return compat.csv_reader(sample, self.header_index)
 
     def to_dict(self):
         raise NotImplementedError
@@ -203,7 +203,7 @@ class DataTable(object):
         """Get headers from stream."""
 
         if reader is None:
-            reader = compat.csv_reader(stream)
+            reader = compat.csv_reader(stream, self.header_index)
         try:
             for index, line in enumerate(reader):
                 if index == self.header_index:


### PR DESCRIPTION
Should solve: #100, #98. 
Since the detection is statistical, having a fixed value isn't suitable for all cases and the detection fails for very short or very long files. 
This implementation starts sampling from 2 rows and continues to add until it finds a delimiter that is not entirely alaphanumeric or space. This solution is the lightest I could come up with. If you have a better idea, please share.  