### PR TITLE
Rename validator to processor in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ Welcome to Good Tables's documentation!
 
 Good Tables is a python library and command line tool for validating and transforming tabular data.
 
-**Tabular data** in the form of CSV or Excel is passed through a pipeline of **validators**. These validators can **check structure**, for example are their blank rows or columns, do rows have the same length as the header etc, and they can also **validate against a schema**, for example does the data have the expected columns, is the data of the right type (are dates actually dates).
+**Tabular data** in the form of CSV or Excel is passed through a pipeline of **processors**. These processors can **check structure**, for example are their blank rows or columns, do rows have the same length as the header etc, and they can also **validate against a schema**, for example does the data have the expected columns, is the data of the right type (are dates actually dates).
 
 Optionally, the data source is **transformed** as it passes through the pipeline.
 
@@ -30,7 +30,7 @@ Table of contents
 
    quickstart
    tutorial
-   validators
+   processors
    pipeline
    batch
    reports

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -3,54 +3,54 @@ Pipeline
 
 Naturally, the `pipeline.Pipeline` class implements the processing pipeline.
 
-Validator registration
+Processor registration
 **********************
 
 Register by constructor
 +++++++++++++++++++++++
 
-The `pipeline.Pipeline` constructor takes a `validators` keyword argument, which is a list of validators to run in the pipeline.
+The `pipeline.Pipeline` constructor takes a `processors` keyword argument, which is a list of processors to run in the pipeline.
 
-Each value in the `validators` list is expected to be a string describing the path to a validator class, for import via `importlib`.
+Each value in the `processors` list is expected to be a string describing the path to a processor class, for import via `importlib`.
 
-Optionally, for builtin validators, the `validator.name` property can be used as a shorthand convenience.
+Optionally, for builtin processors, the `processor.name` property can be used as a shorthand convenience.
 
 **Example**
 ::
-    validators = ['structure', 'schema']  # short hand names for builtin validators
-    validators = ['my_module.CustomValidatorOne', 'my_module.CustomValidatorTwo']  # import from string
-    validators = ['structure', 'my_module.CustomValidatorTwo']  # both combined
+    processors = ['structure', 'schema']  # short hand names for builtin processors
+    processors = ['my_module.CustomProcessorOne', 'my_module.CustomProcessorTwo']  # import from string
+    processors = ['structure', 'my_module.CustomProcessorTwo']  # both combined
 
 Register by instance method
 +++++++++++++++++++++++++++
 
-Once you have a `pipeline.Pipeline` instance, you can also register validators via the `register_validator` method.
+Once you have a `pipeline.Pipeline` instance, you can also register processors via the `register_processor` method.
 
-Registering new validators this way will by default append the new validators to any existing pipeline.
+Registering new processors this way will by default append the new processors to any existing pipeline.
 
 You can define the position in the pipeline explicitly using the `position` argument.
 
 **Example**
 ::
     pipeline = Pipeline(args, kwargs)
-    pipeline.register_validator('structure', structure_options)
-    pipeline.register_validator('spec', spec_options, 0)
+    pipeline.register_processor('structure', structure_options)
+    pipeline.register_processor('spec', spec_options, 0)
 
-Validator options
+Processor options
 *****************
 
-`Pipeline` takes an `options` keyword argument to pass options into each validator in the pipeline.
+`Pipeline` takes an `options` keyword argument to pass options into each processor in the pipeline.
 
-`options` should be a dict, with each top-level key being the name of the validator.
+`options` should be a dict, with each top-level key being the name of the processor.
 
 **Example**
 ::
     pipeline_options = {
         'structure': {
-            # keyword args for the StructureValidator
+            # keyword args for the StructureProcessor
         },
         'schema': {
-            # keyword args for the SchemaValidator
+            # keyword args for the SchemaProcessor
         }
     }
 
@@ -66,50 +66,50 @@ Running the pipeline
 
 Run the pipeline with the `run` method.
 
-`run` in turn calls the supported **validator methods** of each validator.
+`run` in turn calls the supported **processor methods** of each processor.
 
-Once the data table has been run through all validators, `run` returns a tuple of `valid, report`, where:
+Once the data table has been run through all processors, `run` returns a tuple of `valid, report`, where:
 
 * `valid` is a boolean, indicating if the data table is valid according to the pipeline validation
 * `report` is `tellme.Report` instance, which can be used to generate a report in various formats
 
 
-Validator arguments
+Processor arguments
 *******************
 
-Most validators will have custom keyword arguments for their configuration.
+Most processors will have custom keyword arguments for their configuration.
 
-Additionally, all validators are expected to take the following keyword arguments, and exhibit certain behaviour based on their values.
+Additionally, all processors are expected to take the following keyword arguments, and exhibit certain behaviour based on their values.
 
-The `base.Validator` signature implements these arguments.
+The `base.Processor` signature implements these arguments.
 
 `fail_fast`
 +++++++++++
 
 `fail_fast` is a boolean that defaults to `False`.
 
-If `fail_fast` is `True`, the validator is expected to stop processing as soon as an error occurs.
+If `fail_fast` is `True`, the processor is expected to stop processing as soon as an error occurs.
 
 `transform`
 +++++++++++
 
 `transform` is a boolean that defaults to `True`.
 
-If `transform` is `True`, then the validator is "allowed" to return transformed data.
+If `transform` is `True`, then the processor is "allowed" to return transformed data.
 
 The caller (e.g., the pipeline class) is responsible for persisting transformed data.
 
 `report_limit`
 ++++++++++++++
 
-`report_limit` is an int that defaults to `1000`, and refers to the maximum amount of entries that this validator can write to a report.
+`report_limit` is an int that defaults to `1000`, and refers to the maximum amount of entries that this processor can write to a report.
 
-If this number is reached, the validator should stop processing.
+If this number is reached, the processor should stop processing.
 
 `row_limit`
 +++++++++++
 
-`row_limit` is an int that defaults to `20000`, and refers to the maximum amount of rows that this validator will process.
+`row_limit` is an int that defaults to `20000`, and refers to the maximum amount of rows that this processor will process.
 
 `report_stream`
 +++++++++++++++
@@ -117,26 +117,26 @@ If this number is reached, the validator should stop processing.
 `report_stream` allows calling code to pass in a writable, seekable text stream to write report entries to.
 
 
-Validator attributes
+Processor attributes
 ********************
 
-Validators are also expected to have the following attributes.
+Processors are also expected to have the following attributes.
 
 `report`
 ++++++++
 
 A `tellme.Report` instance. See `TellMe`_
 
-Validators are expected to write report entries to the report instance.
+Processors are expected to write report entries to the report instance.
 
-`pipeline.Pipeline` will call `validator.report.generate` for each validator to build the pipeline report.
+`pipeline.Pipeline` will call `processor.report.generate` for each processor to build the pipeline report.
 
 `name`
 ++++++
 
-A shorthand name for this validator. `name` should be unique when called in a pipeline.
+A shorthand name for this processor. `name` should be unique when called in a pipeline.
 
-Validators that inherit from `base.Validator` have a name that defaults to a lower-cased version of the class name.
+Processors that inherit from `base.Processor` have a name that defaults to a lower-cased version of the class name.
 
 
 .. _`TellMe`: https://github.com/okfn/tellme

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -8,7 +8,7 @@ Some tutorials for using and extending Good Tables.
 
 # TODO: This is unfinished.
 
-Implementing a custom validator that can be invoked in a pipeline is easy.
+Implementing a custom processor that can be invoked in a pipeline is easy.
 
 Let's write one that checks that values are in a certain range.
 
@@ -18,13 +18,13 @@ In our data, we have name, age and city data for a group of people.
 
 We want to ensure that all the people in our data are in the 25-50 age range.
 
-For demonstration, we'll write a pretty specific validator for this.
+For demonstration, we'll write a pretty specific processor for this.
 
 Of course the implementation could be made more generic for a range scenarios.
 
-Our validator class::
+Our processor class::
 
-  class AgeRangeValidator(object):
+  class AgeRangeProcessor(object):
       column_name = 'age'
       column_type = int
       column_range = (25, 50)
@@ -53,15 +53,15 @@ However, we could easily run the same validation in the `run_column` instead::
     valid = True
         return valid
 
-So, let's see it in action. First, we'll run the validator in 'stand alone' via its run method::
+So, let's see it in action. First, we'll run the processor in 'stand alone' via its run method::
 
-  validator = AgeRangeValidator()
+  processor = AgeRangeProcessor()
   filepath = 'examples/custom-range.csv'
-  valid, report = validator.run(filepath)
+  valid, report = processor.run(filepath)
 
-And the same, but part of a validation pipeline using the structure validator with our `AgeRangeValidator`::
+And the same, but part of a validation pipeline using the structure processor with our `AgeRangeProcessor`::
 
-  validators = ('structure', 'my_module.AgeRangeValidator')
+  processors = ('structure', 'my_module.AgeRangeProcessor')
   filepath = 'examples/custom-range.csv'
-  validation_pipeline = ValidationPipeline(filepath, validators)
+  validation_pipeline = ValidationPipeline(filepath, processors)
   valid, report = validation_pipeline.run()


### PR DESCRIPTION
In 9b3a3af70193ac69c372eec6388e318cf4f5e864 validators were renamed to processors,
but this name change was not reflected in the documention. This updates the
documentation to match the usage in the code.